### PR TITLE
Update example dependency path

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -17,7 +17,7 @@
         "rxjs": "^7.2.0"
       },
       "devDependencies": {
-        "@e-mage/nestjs-shopify-guards": "file:../e-mage-nestjs-shopify-guards-0.0.2.tgz",
+        "@e-mage/nestjs-shopify-guards": "file:../",
         "@nestjs/cli": "^9.3.0",
         "@nestjs/schematics": "^9.0.0",
         "@nestjs/testing": "^11.1.3",
@@ -39,6 +39,45 @@
         "ts-node": "^10.0.0",
         "tsconfig-paths": "4.1.1",
         "typescript": "^4.7.4"
+      }
+    },
+    "..": {
+      "name": "@e-mage/nestjs-shopify-guards",
+      "version": "1.0.3",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "devDependencies": {
+        "@nestjs/cli": "^9.0.0",
+        "@nestjs/common": "^11.0.16",
+        "@nestjs/core": "^11.0.16",
+        "@nestjs/platform-express": "^11.0.16",
+        "@nestjs/schematics": "^9.0.0",
+        "@nestjs/testing": "^11.0.16",
+        "@types/express": "^4.17.13",
+        "@types/jest": "28.1.4",
+        "@types/node": "^16.0.0",
+        "@types/supertest": "^2.0.11",
+        "@typescript-eslint/eslint-plugin": "^5.0.0",
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^8.0.1",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-prettier": "^4.0.0",
+        "jest": "28.1.2",
+        "prettier": "^2.3.2",
+        "reflect-metadata": "^0.1.13",
+        "release-it": "^15.6.0",
+        "rimraf": "^3.0.2",
+        "rxjs": "^7.2.0",
+        "source-map-support": "^0.5.20",
+        "supertest": "^6.1.3",
+        "ts-jest": "28.0.5",
+        "ts-loader": "^9.2.3",
+        "ts-node": "^10.0.0",
+        "tsconfig-paths": "4.0.0",
+        "typescript": "^4.3.5"
+      },
+      "engines": {
+        "node": ">=20.11.1 <21"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -989,11 +1028,8 @@
       }
     },
     "node_modules/@e-mage/nestjs-shopify-guards": {
-      "version": "0.0.2",
-      "resolved": "file:../e-mage-nestjs-shopify-guards-0.0.2.tgz",
-      "integrity": "sha512-M4tLUsnUHeK5ZCrFRNOZU6Foa53Er58ZtPFBCA4Ig5xTH8+nIJSTGiar/UJBDUN4JqGcb0GqQ0twzQhcTAIZGA==",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "..",
+      "link": true
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.4.1",
@@ -9213,9 +9249,37 @@
       }
     },
     "@e-mage/nestjs-shopify-guards": {
-      "version": "file:../e-mage-nestjs-shopify-guards-0.0.2.tgz",
-      "integrity": "sha512-M4tLUsnUHeK5ZCrFRNOZU6Foa53Er58ZtPFBCA4Ig5xTH8+nIJSTGiar/UJBDUN4JqGcb0GqQ0twzQhcTAIZGA==",
-      "dev": true
+      "version": "file:..",
+      "requires": {
+        "@nestjs/cli": "^9.0.0",
+        "@nestjs/common": "^11.0.16",
+        "@nestjs/core": "^11.0.16",
+        "@nestjs/platform-express": "^11.0.16",
+        "@nestjs/schematics": "^9.0.0",
+        "@nestjs/testing": "^11.0.16",
+        "@types/express": "^4.17.13",
+        "@types/jest": "28.1.4",
+        "@types/node": "^16.0.0",
+        "@types/supertest": "^2.0.11",
+        "@typescript-eslint/eslint-plugin": "^5.0.0",
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^8.0.1",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-prettier": "^4.0.0",
+        "jest": "28.1.2",
+        "prettier": "^2.3.2",
+        "reflect-metadata": "^0.1.13",
+        "release-it": "^15.6.0",
+        "rimraf": "^3.0.2",
+        "rxjs": "^7.2.0",
+        "source-map-support": "^0.5.20",
+        "supertest": "^6.1.3",
+        "ts-jest": "28.0.5",
+        "ts-loader": "^9.2.3",
+        "ts-node": "^10.0.0",
+        "tsconfig-paths": "4.0.0",
+        "typescript": "^4.3.5"
+      }
     },
     "@eslint/eslintrc": {
       "version": "1.4.1",

--- a/example/package.json
+++ b/example/package.json
@@ -28,7 +28,7 @@
     "rxjs": "^7.2.0"
   },
   "devDependencies": {
-    "@e-mage/nestjs-shopify-guards": "file:../e-mage-nestjs-shopify-guards-0.0.2.tgz",
+    "@e-mage/nestjs-shopify-guards": "file:../",
     "@nestjs/cli": "^9.3.0",
     "@nestjs/schematics": "^9.0.0",
     "@nestjs/testing": "^11.1.3",


### PR DESCRIPTION
## Summary
- use local build for `@e-mage/nestjs-shopify-guards` in example
- refresh example `package-lock.json`

## Testing
- `npm test`
- `npm test` in `example` *(fails: Cannot find module '@e-mage/nestjs-shopify-guards')*

------
https://chatgpt.com/codex/tasks/task_e_6842be098b54832e8c044e2d6a1a7f28