### PR TITLE
Improve Shopify HMAC verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NestJS guards for Shopify HMAC verification
 
 This module implements Guards which verifies the HMAC signature of incoming requests from Shopify: 
-* `ShopifyAuthGuard` - verifies the HMAC signature of incoming Auth requests from Shopify as described in the [Shopify documentation](https://shopify.dev/apps/auth/oauth/getting-started#step-2-verify-the-installation-request) and will throw an UnauthorizedException if it is invalid.
+* `ShopifyAuthGuard` - verifies the HMAC signature of incoming Auth requests from Shopify as described in the [Shopify documentation](https://shopify.dev/apps/auth/oauth/getting-started#step-2-verify-the-installation-request) and will throw an UnauthorizedException if it is invalid. It also checks that the provided `timestamp` parameter is recent to prevent replay attacks.
 * `ShopifyWebhookGuard` - verifies the HMAC signature of incoming Webhook requests from Shopify as described in the [Shopify documentation](https://shopify.dev/apps/webhooks/getting-started#verify-webhook) and will throw an UnauthorizedException if it is invalid.
 
 ## Basic usage with all default
@@ -54,7 +54,7 @@ export class AppController {
 }
 ```
 ## You can also use the guards with custom options 
-You can change the default hmac header name or the default hmac query parameter name:
+You can change the default HMAC header name, the default HMAC query parameter name, or the allowed timestamp leeway:
 
 ```typescript
 import { ShopifyGuardsModule } from '@e-mage/nestjs-shopify-guards';
@@ -63,8 +63,9 @@ import { ShopifyGuardsModule } from '@e-mage/nestjs-shopify-guards';
     imports: [
         ShopifyGuardsModule.register({
             apiSecretKey: 'my_client_secret',
-            hmacHeaderName: 'X-My-Shopify-Hmac-Sha256',
-            hmacQueryParameterName: 'my-hmac',
+            headerHmac: 'X-My-Shopify-Hmac-Sha256',
+            queryHmac: 'my-hmac',
+            timestampLeewaySec: 3600,
         }),
     ],
     controllers: [AppController],

--- a/lib/config-service.ts
+++ b/lib/config-service.ts
@@ -11,6 +11,7 @@ export class ConfigService {
     apiSecretKey: '',
     headerHmac: 'x-shopify-hmac-sha256',
     queryHmac: 'hmac',
+    timestampLeewaySec: 60 * 60 * 24,
   };
   constructor(
     @Inject(SHOPIFY_GUARDS_MODULE_OPTIONS)
@@ -23,7 +24,9 @@ export class ConfigService {
    * Config getter
    * @param key
    */
-  get(key: string): string {
+  get<K extends keyof ShopifyGuardsModuleOptions>(
+    key: K,
+  ): ShopifyGuardsModuleOptions[K] {
     return this.options[key];
   }
 }

--- a/lib/guards/shopify-auth.guard.ts
+++ b/lib/guards/shopify-auth.guard.ts
@@ -1,4 +1,4 @@
-import { createHmac } from 'crypto';
+import { createHmac, timingSafeEqual } from 'crypto';
 import {
   CanActivate,
   ExecutionContext,
@@ -53,18 +53,39 @@ export class ShopifyAuthGuard implements CanActivate {
       );
     }
 
+    const params = new URLSearchParams(restQuery as Record<string, string>);
+    params.sort();
     const digest = createHmac('sha256', this.config.get('apiSecretKey'))
-      .update(decodeURIComponent(new URLSearchParams(restQuery).toString()))
+      .update(decodeURIComponent(params.toString()))
       .digest('hex');
 
-    // The HMAC is valid if the digest matches the HMAC value
-    if (hmac !== digest) {
+    const isValid =
+      typeof hmac === 'string' &&
+      hmac.length === digest.length &&
+      timingSafeEqual(Buffer.from(hmac), Buffer.from(digest));
+
+    // timestamp validation as recommended by Shopify
+    const timestamp = parseInt(query.timestamp as string, 10);
+    const leeway = this.config.get('timestampLeewaySec') ?? 0;
+    const now = Date.now() / 1000;
+    const isTimestampValid =
+      !timestamp ||
+      (Number.isFinite(timestamp) && now - timestamp <= Number(leeway));
+
+    if (!isValid) {
       throw new HttpException(
         'HMAC validation failed',
         HttpStatus.UNAUTHORIZED,
       );
-    } else {
-      return true;
     }
+
+    if (!isTimestampValid) {
+      throw new HttpException(
+        'HMAC timestamp expired',
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
+
+    return true;
   }
 }

--- a/lib/guards/shopify-webhook.guard.ts
+++ b/lib/guards/shopify-webhook.guard.ts
@@ -1,4 +1,4 @@
-import { createHmac } from 'crypto';
+import { createHmac, timingSafeEqual } from 'crypto';
 import {
   CanActivate,
   ExecutionContext,
@@ -65,14 +65,18 @@ export class ShopifyWebhookGuard implements CanActivate {
       .update(rawBody)
       .digest('base64');
 
-    // The HMAC is valid if the digest matches the HMAC value
-    if (hmac !== digest) {
+    const isValid =
+      typeof hmac === 'string' &&
+      hmac.length === digest.length &&
+      timingSafeEqual(Buffer.from(hmac), Buffer.from(digest));
+
+    if (!isValid) {
       throw new HttpException(
         'HMAC validation failed',
         HttpStatus.UNAUTHORIZED,
       );
-    } else {
-      return true;
     }
+
+    return true;
   }
 }

--- a/lib/interfaces/shopify-guards-module-options.interface.ts
+++ b/lib/interfaces/shopify-guards-module-options.interface.ts
@@ -2,4 +2,9 @@ export interface ShopifyGuardsModuleOptions {
   apiSecretKey: string;
   headerHmac?: string;
   queryHmac?: string;
+  /**
+   * Allowed age of the OAuth timestamp in seconds
+   * defaults to 86400 (24 hours)
+   */
+  timestampLeewaySec?: number;
 }


### PR DESCRIPTION
## Summary
- add constant-time HMAC comparison using `timingSafeEqual`
- sort query parameters before creating HMAC digest for auth requests
- validate OAuth timestamp to prevent replay attacks
- expose `timestampLeewaySec` configuration option in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842c6108868832ea7c2b59a6abd1702